### PR TITLE
Update trcini to initialise fabm vertical movement param

### DIFF
--- a/src/TOP/trcini.F90
+++ b/src/TOP/trcini.F90
@@ -176,6 +176,7 @@ CONTAINS
       IF( ln_fabm    ) THEN
         CALL trc_nam_fabm_override(sn_tracer)
         CALL trc_ini_fabm       ! FABM tracers
+        CALL trc_nam_fabm
       END IF
       ! FABM <<<+++
 


### PR DESCRIPTION
From testing new FABM vertical movement function it appears that the `nn_adv` parameter is not set from name list